### PR TITLE
Change the initial spawn height to be about 10% down from the top of the screen

### DIFF
--- a/Mozilla/MozillaScene.m
+++ b/Mozilla/MozillaScene.m
@@ -101,7 +101,8 @@ NSString *RandomIconName() {
 
     SKAction *createIconAction = [SKAction runBlock:^{
         SKSpriteNode *icon = [SKSpriteNode spriteNodeWithImageNamed: [[NSBundle bundleForClass: [self class]] pathForImageResource: RandomIconName()]];
-        icon.position = CGPointMake(random() % (u_int32_t) CGRectGetWidth(self.frame), 700);
+        CGFloat startingHeight = view.frame.size.height - (view.frame.size.height * 0.1);
+        icon.position = CGPointMake(random() % (u_int32_t) CGRectGetWidth(self.frame), startingHeight);
         icon.size = RandomSize();
         icon.physicsBody = [SKPhysicsBody bodyWithCircleOfRadius: icon.size.width / 2];
         icon.physicsBody.dynamic = YES;


### PR DESCRIPTION
On my big display, the Firefox logos are spawning just about the Mozilla logo. I think it looks better if they spawn a bit higher, as then they have a little way to fall before they hit the logo.

I've also changed this to a percentage of the screen height, as this will hopefully make it more consistent across different screens.